### PR TITLE
Force assending order of quantities in PriceTierProvider.php

### DIFF
--- a/src/Provider/PriceTierProvider.php
+++ b/src/Provider/PriceTierProvider.php
@@ -64,6 +64,9 @@ final class PriceTierProvider implements PriceTierProviderInterface
             $quantities[$priceTier->getQuantity()][] = $priceTier;
         }
 
+        // Sort quantities in ascending order by key in case they were stored "out of order" in the DB
+        ksort($quantities, SORT_NUMERIC);
+
         $resolvedPriceTiers = [];
 
         foreach ($quantities as $priceTiers) {


### PR DESCRIPTION
PriceTierProvider::getPriceTiers returnere tier niveauerne i den rækkefølge de er gemt i DB. Hvis man forventer at de kommer i stigende rækkefølge vil det ikke være tilfældet hvis tier niveauerne af en eller anden grund ikke er gemt i stigende rækkefølge i databasen. Denne sortering vil sikre at de altid kommer i stigende rækkefølge når getPriceTiers kaldes.